### PR TITLE
TEST: Structurally invalid trans-spec

### DIFF
--- a/trans_specs/ARIC/test_invalid_schema.yaml
+++ b/trans_specs/ARIC/test_invalid_schema.yaml
@@ -1,0 +1,4 @@
+- not_a_real_field: true
+  bogus_derivations:
+    Demography:
+      populated_from: pht004053


### PR DESCRIPTION
## Purpose

Test PR to verify CI catches schema violations. **Do not merge.**

Adds a valid YAML file that uses `not_a_real_field` and `bogus_derivations` instead of `class_derivations`. Valid YAML syntax, but invalid against the linkml-map TransformationSpecification schema.

Expected: CI should fail on this PR.