### PR TITLE
Pull FHS person.yaml fix for pht000094 references

### DIFF
--- a/trans_specs/FHS/FHS-v35/person.yaml
+++ b/trans_specs/FHS/FHS-v35/person.yaml
@@ -98,76 +98,76 @@
 #                      '1': OMOP:434489
 #                  age_at_death:
 #                    expr: '{pht002075.phv00141916} * 365'
-                  cause_of_death:
-                    object_derivations:
-                    - class_derivations:
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021941
-                            order:
-                              value: 1        
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021942
-                            order:
-                              value: 2
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021943
-                            order:
-                              value: 3
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021944
-                            order:
-                              value: 4 
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021945
-                            order:
-                              value: 5
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021946
-                            order:
-                              value: 6
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021947
-                            order:
-                              value: 7
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021948
-                            order:
-                              value: 8
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021949
-                            order:
-                              value: 9
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021950
-                            order:
-                              value: 10
+#                  cause_of_death:
+#                    object_derivations:
+#                    - class_derivations:
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021941
+#                            order:
+#                              value: 1        
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021942
+#                            order:
+#                              value: 2
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021943
+#                            order:
+#                              value: 3
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021944
+#                            order:
+#                              value: 4 
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021945
+#                            order:
+#                              value: 5
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021946
+#                            order:
+#                              value: 6
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021947
+#                            order:
+#                              value: 7
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021948
+#                            order:
+#                              value: 8
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021949
+#                            order:
+#                              value: 9
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021950
+#                            order:
+#                              value: 10


### PR DESCRIPTION
## Summary

Sync FHS person.yaml with upstream fix for `ValueError: No such class: "pht000094"` — the last 2 pipeline errors across all 9 cohorts.

Upstream issue: RTIInternational/NHLBI-BDC-DMC-HV#450

## Test plan

- [ ] Run pipeline against FHS — 0 errors
- [ ] All 9 cohorts clean